### PR TITLE
Add observability with OpenTelemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The best way to get started is to copy one of the pre-built workflows from the [
 
 Here are some of the available examples:
 
-- [`gemini-issue-triage.yml`](./examples/gemini-issue-triage.yml): Automatically analyzes and applies appropriate labels to newly opened issues. Can also be manually triggered by commenting `@gemini /triage`.
+- [`gemini-issue-triage.yml`](./examples/gemini-issue-triage.yml): Automatically analyzes and applies appropriate labels to newly opened or reopened issues.
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,11 @@ Here are some of the available examples:
 
 ## Inputs
 
-- `GEMINI_API_KEY` (required): Your Gemini API key, stored as a GitHub secret.
 - `prompt` (optional): A specific, multi-line prompt to guide Gemini's behavior. This is where you define the persona, workflow, and instructions for the model. The default is `'You are a helpful assistant.'`.
+- `GEMINI_API_KEY` (required): Your Gemini API key, stored as a GitHub secret.
+- `OTLP_GCP_WIF_PROVIDER` (optional): The workload identity provider for GCP authentication.
+- `OTLP_GCP_SERVICE_ACCOUNT` (optional): The service account for GCP authentication.
+- `OTLP_GOOGLE_CLOUD_PROJECT` (optional): The Google Cloud project for telemetry.
 
 ## Authentication
 
@@ -46,6 +49,12 @@ When you create your GitHub App, you must grant it the correct permissions for y
 **Important**: The permissions above are a baseline for the examples. If you create custom workflows that interact with the GitHub API in other ways (e.g., modifying projects, creating branches, managing deployments), you must update your GitHub App's permissions to grant the necessary access. Always follow the principle of least privilege, granting only the permissions your specific workflow requires.
 
 For more information on creating and using GitHub Apps, see the [documentation](https://docs.github.com/en/developers/apps).
+
+## Observability with OpenTelemetry
+
+This action can be configured to send telemetry data to your own Google Cloud project for observability. This allows you to monitor the performance and behavior of the Gemini CLI within your workflows.
+
+For detailed instructions on how to set up and configure observability, please see the [Observability documentation](./docs/observability.md).
 
 ## Customization
 

--- a/action.yml
+++ b/action.yml
@@ -3,17 +3,41 @@ description: 'Uses the Gemini CLI to automate software development tasks.'
 author: 'Gemini'
 
 inputs:
-  GEMINI_API_KEY:
-    description: 'Your Gemini API key.'
-    required: true
   prompt:
     description: 'A specific prompt to guide Gemini.'
     required: false
     default: 'You are a helpful assistant.'
+  GEMINI_API_KEY:
+    description: 'Your Gemini API key.'
+    required: true
+  OTLP_GCP_WIF_PROVIDER:
+    description: 'The workload identity provider for GCP authentication.'
+    required: false
+  OTLP_GCP_SERVICE_ACCOUNT:
+    description: 'The service account for GCP authentication.'
+    required: false
+  OTLP_GOOGLE_CLOUD_PROJECT:
+    description: 'The Google Cloud project for telemetry.'
+    required: false
 
 runs:
   using: "composite"
   steps:
+    - name: Authenticate to Google Cloud for Telemetry 
+      if: inputs.OTLP_GCP_WIF_PROVIDER != ''
+      id: auth
+      uses: 'google-github-actions/auth@v2'
+      with:
+        workload_identity_provider: ${{ inputs.OTLP_GCP_WIF_PROVIDER }}
+        service_account: ${{ inputs.OTLP_GCP_SERVICE_ACCOUNT }}
+
+    - name: Run Telemetry Collector for Google Cloud
+      if: inputs.OTLP_GCP_WIF_PROVIDER != ''
+      run: node scripts/telemetry.js &
+      shell: bash
+      env:
+        OTLP_GOOGLE_CLOUD_PROJECT: ${{ inputs.OTLP_GOOGLE_CLOUD_PROJECT }}
+
     - run: npm install -g @google/gemini-cli
       shell: bash
     - run: gemini --yolo --prompt "${{ inputs.prompt }}"

--- a/docs/issue-triage.md
+++ b/docs/issue-triage.md
@@ -4,8 +4,8 @@ This workflow provides a comprehensive system for triaging GitHub issues using t
 
 ## Features
 
-- **Automated Triage**: When a new issue is opened, the action will automatically analyze it and apply relevant labels.
+- **Automated Triage**: When an issue is opened or reopened, the action will automatically analyze it and apply relevant labels.
 
 ## How it Works
 
-The workflow is defined in `examples/gemini-issue-triage.yml` and is triggered when a new issue is opened.
+The workflow is defined in `examples/gemini-issue-triage.yml` and is triggered when an issue is opened or reopened.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,37 @@
+# Observability with OpenTelemetry
+
+This action can be configured to send telemetry data to your own Google Cloud project for observability. This allows you to monitor the performance and behavior of the Gemini CLI within your workflows.
+
+## Setup
+
+To set up the necessary Google Cloud resources, you can use the provided script. This script will create a service account, grant it the necessary permissions, and configure Workload Identity Federation.
+
+```bash
+./scripts/setup_workload_identity.sh <GCP_PROJECT_ID> <GITHUB_REPO>
+```
+
+Replace `<GCP_PROJECT_ID>` with your Google Cloud project ID and `<GITHUB_REPO>` with your GitHub repository in the format `owner/repo`.
+
+The script will output the names and values for the secrets you need to add to your GitHub repository.
+
+### Manual Setup
+
+If you prefer to set up the resources manually, you can follow these steps:
+
+1.  **Create a Google Cloud Service Account for OTLP**
+2.  **Grant IAM Permissions to the OTLP Service Account**
+3.  **Set Up Workload Identity Federation**
+4.  **Allow the OTLP Service Account to be Impersonated**
+5.  **Configure OTLP-Specific GitHub Secrets**
+
+For detailed instructions on each of these steps, please refer to the [Google Cloud documentation on Workload Identity Federation](https://cloud.google.com/iam/docs/workload-identity-federation).
+
+## Inputs
+
+To enable this feature, you will need to provide the following inputs in your GitHub Actions workflow:
+
+- `OTLP_GCP_WIF_PROVIDER`: The Workload Identity Federation provider for authenticating to Google Cloud.
+- `OTLP_GCP_SERVICE_ACCOUNT`: The service account to use for authentication.
+- `OTLP_GOOGLE_CLOUD_PROJECT`: The Google Cloud project where you want to send your telemetry data.
+
+When enabled, the action will automatically start an OpenTelemetry collector that forwards traces, metrics, and logs to your specified GCP project. You can then use Google Cloud's operations suite (formerly Stackdriver) to visualize and analyze this data.

--- a/scripts/setup_workload_identity.sh
+++ b/scripts/setup_workload_identity.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+# This script configures Google Cloud Workload Identity Federation for a GitHub repository.
+
+set -e
+
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 <GCP_PROJECT_ID> <GITHUB_REPO>"
+    echo "  - GCP_PROJECT_ID: Your Google Cloud project ID."
+    echo "  - GITHUB_REPO: Your GitHub repository in the format 'owner/repo'."
+    exit 1
+fi
+
+export OTLP_PROJECT_ID="$1"
+export GITHUB_REPO="$2"
+
+export OTLP_SERVICE_ACCOUNT_NAME="github-otlp-telemetry"
+export OTLP_POOL_NAME="github-actions-pool"
+
+echo "🚀 Starting Workload Identity Federation setup for project '$OTLP_PROJECT_ID' and repo '$GITHUB_REPO'..."
+
+# Step 1: Create a Google Cloud Service Account for OTLP
+echo "
+[Step 1/5] 👤 Checking for service account '${OTLP_SERVICE_ACCOUNT_NAME}'..."
+if ! gcloud iam service-accounts describe ${OTLP_SERVICE_ACCOUNT_NAME}@${OTLP_PROJECT_ID}.iam.gserviceaccount.com --project=${OTLP_PROJECT_ID} &> /dev/null; then
+    echo "Service account not found, creating..."
+    gcloud iam service-accounts create ${OTLP_SERVICE_ACCOUNT_NAME} \
+      --project=${OTLP_PROJECT_ID} \
+      --display-name="GitHub Actions OTLP Telemetry"
+else
+    echo "Service account already exists."
+fi
+
+# Step 2: Grant IAM Permissions to the OTLP Service Account
+echo "
+[Step 2/5] 🔑 Granting IAM permissions to the service account..."
+gcloud projects add-iam-policy-binding ${OTLP_PROJECT_ID} \
+  --member="serviceAccount:${OTLP_SERVICE_ACCOUNT_NAME}@${OTLP_PROJECT_ID}.iam.gserviceaccount.com" \
+  --role="roles/cloudtrace.agent" --condition=None
+gcloud projects add-iam-policy-binding ${OTLP_PROJECT_ID} \
+  --member="serviceAccount:${OTLP_SERVICE_ACCOUNT_NAME}@${OTLP_PROJECT_ID}.iam.gserviceaccount.com" \
+  --role="roles/monitoring.metricWriter" --condition=None
+gcloud projects add-iam-policy-binding ${OTLP_PROJECT_ID} \
+  --member="serviceAccount:${OTLP_SERVICE_ACCOUNT_NAME}@${OTLP_PROJECT_ID}.iam.gserviceaccount.com" \
+  --role="roles/logging.logWriter" --condition=None
+
+# Step 3: Set Up Workload Identity Federation
+echo "
+[Step 3/5] 🔗 Setting up Workload Identity Federation..."
+
+if ! gcloud iam workload-identity-pools describe ${OTLP_POOL_NAME} --project=${OTLP_PROJECT_ID} --location="global" &> /dev/null; then
+    echo "Creating Workload Identity Pool '${OTLP_POOL_NAME}'..."
+    gcloud iam workload-identity-pools create ${OTLP_POOL_NAME} \
+      --project=${OTLP_PROJECT_ID} \
+      --location="global" \
+      --display-name="GitHub Actions Pool"
+else
+    echo "Workload Identity Pool '${OTLP_POOL_NAME}' already exists."
+fi
+
+export OTLP_POOL_ID=$(gcloud iam workload-identity-pools describe ${OTLP_POOL_NAME} \
+  --project=${OTLP_PROJECT_ID} \
+  --location="global" \
+  --format="value(name)")
+
+if ! gcloud iam workload-identity-pools providers describe "github-provider" --project=${OTLP_PROJECT_ID} --location="global" --workload-identity-pool=${OTLP_POOL_NAME} &> /dev/null; then
+    echo "Creating Workload Identity Provider 'github-provider'..."
+    gcloud iam workload-identity-pools providers create-oidc "github-provider" \
+      --project=${OTLP_PROJECT_ID} \
+      --location="global" \
+      --workload-identity-pool=${OTLP_POOL_NAME} \
+      --display-name="GitHub Provider" \
+      --attribute-mapping="google.subject=assertion.sub,attribute.actor=assertion.actor,attribute.repository=assertion.repository" \
+      --issuer-uri="https://token.actions.githubusercontent.com"
+else
+    echo "Workload Identity Provider 'github-provider' already exists."
+fi
+
+# Step 4: Allow the OTLP Service Account to be Impersonated
+echo "
+[Step 4/5] 🤝 Allowing the service account to be impersonated..."
+gcloud iam service-accounts add-iam-policy-binding "${OTLP_SERVICE_ACCOUNT_NAME}@${OTLP_PROJECT_ID}.iam.gserviceaccount.com" \
+  --project=${OTLP_PROJECT_ID} \
+  --role="roles/iam.workloadIdentityUser" \
+  --member="principalSet://iam.googleapis.com/${OTLP_POOL_ID}/attribute.repository/${GITHUB_REPO}" --condition=None
+
+# Step 5: Configure OTLP-Specific GitHub Secrets
+echo "
+[Step 5/5] 🤫 Please configure the following secrets in your GitHub repository's settings:"
+
+OTLP_GCP_SA_EMAIL="${OTLP_SERVICE_ACCOUNT_NAME}@${OTLP_PROJECT_ID}.iam.gserviceaccount.com"
+OTLP_GCP_WIF_PROVIDER=$(gcloud iam workload-identity-pools providers describe "github-provider" \
+  --project=${OTLP_PROJECT_ID} \
+  --location="global" \
+  --workload-identity-pool=${OTLP_POOL_NAME} \
+  --format="value(name)")
+
+echo "
+  OTLP_GCP_SERVICE_ACCOUNT: ${OTLP_GCP_SA_EMAIL}"
+echo "  OTLP_GCP_WIF_PROVIDER: ${OTLP_GCP_WIF_PROVIDER}"
+echo "  OTLP_GOOGLE_CLOUD_PROJECT: ${OTLP_PROJECT_ID}"
+
+echo "
+🎉✨🚀 Setup complete! 🚀✨🎉"

--- a/scripts/telemetry.js
+++ b/scripts/telemetry.js
@@ -1,0 +1,14 @@
+import { execSync } from 'child_process';
+import { join } from 'path';
+
+const projectRoot = join(import.meta.dirname, '..');
+const scriptPath = join(projectRoot, 'scripts', 'telemetry_gcp.js');
+
+try {
+  console.log(`🚀 Running telemetry script for target: gcp.`);
+  execSync(`node ${scriptPath}`, { stdio: 'inherit', cwd: projectRoot });
+} catch (error) {
+  console.error(`🛑 Failed to run telemetry script for target: gcp`);
+  console.error(error);
+  process.exit(1);
+}

--- a/scripts/telemetry_gcp.js
+++ b/scripts/telemetry_gcp.js
@@ -1,0 +1,180 @@
+import path from 'path';
+import fs from 'fs';
+import { spawn, execSync } from 'child_process';
+import {
+  OTEL_DIR,
+  BIN_DIR,
+  fileExists,
+  waitForPort,
+  ensureBinary,
+  manageTelemetrySettings,
+  registerCleanup,
+} from './telemetry_utils.js';
+
+const OTEL_CONFIG_FILE = path.join(OTEL_DIR, 'collector-gcp.yaml');
+const OTEL_LOG_FILE = path.join(OTEL_DIR, 'collector-gcp.log');
+
+const getOtelConfigContent = (projectId) => `
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: "localhost:4317"
+processors:
+  batch:
+    timeout: 1s
+exporters:
+  googlecloud:
+    project: "${projectId}"
+    metric:
+      prefix: "custom.googleapis.com/gemini_cli"
+    log:
+      default_log_name: "gemini_cli"
+  debug:
+    verbosity: detailed
+service:
+  telemetry:
+    logs:
+      level: "debug"
+    metrics:
+      level: "none"
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [googlecloud]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [googlecloud, debug]
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [googlecloud, debug]
+`;
+
+async function main() {
+  console.log('✨ Starting Local Telemetry Exporter for Google Cloud ✨');
+
+  let collectorProcess;
+  let collectorLogFd;
+
+  const originalSandboxSetting = manageTelemetrySettings(
+    true,
+    'http://localhost:4317',
+    'gcp',
+  );
+  registerCleanup(
+    () => [collectorProcess].filter((p) => p), // Function to get processes
+    () => [collectorLogFd].filter((fd) => fd), // Function to get FDs
+    originalSandboxSetting,
+  );
+
+  const projectId = process.env.OTLP_GOOGLE_CLOUD_PROJECT;
+  if (!projectId) {
+    console.error(
+      '🛑 Error: OTLP_GOOGLE_CLOUD_PROJECT environment variable is not exported.',
+    );
+    console.log(
+      '   Please set it to your Google Cloud Project ID and try again.',
+    );
+    console.log('   `export OTLP_GOOGLE_CLOUD_PROJECT=your-project-id`');
+    process.exit(1);
+  }
+  console.log(`✅ Using OTLP Google Cloud Project ID: ${projectId}`);
+
+  console.log('\n🔑 Please ensure you are authenticated with Google Cloud:');
+  console.log(
+    '  - Run `gcloud auth application-default login` OR ensure `GOOGLE_APPLICATION_CREDENTIALS` environment variable points to a valid service account key.',
+  );
+  console.log(
+    '  - The account needs "Cloud Trace Agent", "Monitoring Metric Writer", and "Logs Writer" roles.',
+  );
+
+  if (!fileExists(BIN_DIR)) fs.mkdirSync(BIN_DIR, { recursive: true });
+
+  const otelcolPath = await ensureBinary(
+    'otelcol-contrib',
+    'open-telemetry/opentelemetry-collector-releases',
+    (version, platform, arch, ext) =>
+      `otelcol-contrib_${version}_${platform}_${arch}.${ext}`,
+    'otelcol-contrib',
+    false, // isJaeger = false
+  ).catch((e) => {
+    console.error(`🛑 Error getting otelcol-contrib: ${e.message}`);
+    return null;
+  });
+  if (!otelcolPath) process.exit(1);
+
+  console.log('🧹 Cleaning up old processes and logs...');
+  try {
+    execSync('pkill -f "otelcol-contrib"');
+    console.log('✅ Stopped existing otelcol-contrib process.');
+  } catch (_e) {
+    /* no-op */
+  }
+  try {
+    fs.unlinkSync(OTEL_LOG_FILE);
+    console.log('✅ Deleted old GCP collector log.');
+  } catch (e) {
+    if (e.code !== 'ENOENT') console.error(e);
+  }
+
+  if (!fileExists(OTEL_DIR)) fs.mkdirSync(OTEL_DIR, { recursive: true });
+  fs.writeFileSync(OTEL_CONFIG_FILE, getOtelConfigContent(projectId));
+  console.log(`📄 Wrote OTEL collector config to ${OTEL_CONFIG_FILE}`);
+
+  console.log(`🚀 Starting OTEL collector for GCP... Logs: ${OTEL_LOG_FILE}`);
+  collectorLogFd = fs.openSync(OTEL_LOG_FILE, 'a');
+  collectorProcess = spawn(otelcolPath, ['--config', OTEL_CONFIG_FILE], {
+    stdio: ['ignore', collectorLogFd, collectorLogFd],
+    env: { ...process.env },
+  });
+
+  console.log(
+    `⏳ Waiting for OTEL collector to start (PID: ${collectorProcess.pid})...`,
+  );
+
+  try {
+    await waitForPort(4317);
+    console.log(`✅ OTEL collector started successfully on port 4317.`);
+  } catch (err) {
+    console.error(`🛑 Error: OTEL collector failed to start on port 4317.`);
+    console.error(err.message);
+    if (collectorProcess && collectorProcess.pid) {
+      process.kill(collectorProcess.pid, 'SIGKILL');
+    }
+    if (fileExists(OTEL_LOG_FILE)) {
+      console.error('📄 OTEL Collector Log Output:');
+      console.error(fs.readFileSync(OTEL_LOG_FILE, 'utf-8'));
+    }
+    process.exit(1);
+  }
+
+  collectorProcess.on('error', (err) => {
+    console.error(`${collectorProcess.spawnargs[0]} process error:`, err);
+    process.exit(1);
+  });
+
+  console.log(`\n✨ Local OTEL collector for GCP is running.`);
+  console.log(
+    '\n🚀 To send telemetry, run the Gemini CLI in a separate terminal window.',
+  );
+  console.log(`\n📄 Collector logs are being written to: ${OTEL_LOG_FILE}`);
+  console.log(
+    `📄 Tail collector logs in another terminal: tail -f ${OTEL_LOG_FILE}`,
+  );
+  console.log(`\n📊 View your telemetry data in Google Cloud Console:`);
+  console.log(
+    `   - Logs: https://console.cloud.google.com/logs/query;query=logName%3D%22projects%2F${projectId}%2Flogs%2Fgemini_cli%22?project=${projectId}`,
+  );
+  console.log(
+    `   - Metrics: https://console.cloud.google.com/monitoring/metrics-explorer?project=${projectId}`,
+  );
+  console.log(
+    `   - Traces: https://console.cloud.google.com/traces/list?project=${projectId}`,
+  );
+  console.log(`\nPress Ctrl+C to exit.`);
+}
+
+main();

--- a/scripts/telemetry_utils.js
+++ b/scripts/telemetry_utils.js
@@ -1,0 +1,394 @@
+import path from 'path';
+import fs from 'fs';
+import net from 'net';
+import os from 'os';
+import { execSync } from 'child_process';
+import { fileURLToPath } from 'url';
+import crypto from 'node:crypto';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const projectRoot = path.resolve(__dirname, '..');
+const projectHash = crypto
+  .createHash('sha256')
+  .update(projectRoot)
+  .digest('hex');
+
+// User-level .gemini directory in home
+const USER_GEMINI_DIR = path.join(os.homedir(), '.gemini');
+// Project-level .gemini directory in the workspace
+const WORKSPACE_GEMINI_DIR = path.join(projectRoot, '.gemini');
+
+// Telemetry artifacts are stored in a hashed directory under the user's ~/.gemini/tmp
+export const OTEL_DIR = path.join(USER_GEMINI_DIR, 'tmp', projectHash, 'otel');
+export const BIN_DIR = path.join(OTEL_DIR, 'bin');
+
+// Workspace settings remain in the project's .gemini directory
+export const WORKSPACE_SETTINGS_FILE = path.join(
+  WORKSPACE_GEMINI_DIR,
+  'settings.json',
+);
+
+export function getJson(url) {
+  const tmpFile = path.join(
+    os.tmpdir(),
+    `gemini-cli-releases-${Date.now()}.json`,
+  );
+  try {
+    execSync(
+      `curl -sL -H "User-Agent: gemini-cli-dev-script" -o "${tmpFile}" "${url}"`,
+      { stdio: 'pipe' },
+    );
+    const content = fs.readFileSync(tmpFile, 'utf-8');
+    return JSON.parse(content);
+  } catch (e) {
+    console.error(`Failed to fetch or parse JSON from ${url}`);
+    throw e;
+  } finally {
+    if (fs.existsSync(tmpFile)) {
+      fs.unlinkSync(tmpFile);
+    }
+  }
+}
+
+export function downloadFile(url, dest) {
+  try {
+    execSync(`curl -fL -sS -o "${dest}" "${url}"`, {
+      stdio: 'pipe',
+    });
+    return dest;
+  } catch (e) {
+    console.error(`Failed to download file from ${url}`);
+    throw e;
+  }
+}
+
+export function findFile(startPath, filter) {
+  if (!fs.existsSync(startPath)) {
+    return null;
+  }
+  const files = fs.readdirSync(startPath);
+  for (const file of files) {
+    const filename = path.join(startPath, file);
+    const stat = fs.lstatSync(filename);
+    if (stat.isDirectory()) {
+      const result = findFile(filename, filter);
+      if (result) return result;
+    }
+    else if (filter(file)) {
+      return filename;
+    }
+  }
+  return null;
+}
+
+export function fileExists(filePath) {
+  return fs.existsSync(filePath);
+}
+
+export function readJsonFile(filePath) {
+  if (!fileExists(filePath)) {
+    return {};
+  }
+  const content = fs.readFileSync(filePath, 'utf-8');
+  try {
+    return JSON.parse(content);
+  } catch (e) {
+    console.error(`Error parsing JSON from ${filePath}: ${e.message}`);
+    return {};
+  }
+}
+
+export function writeJsonFile(filePath, data) {
+  fs.writeFileSync(filePath, JSON.stringify(data, null, 2));
+}
+
+export function waitForPort(port, timeout = 10000) {
+  return new Promise((resolve, reject) => {
+    const startTime = Date.now();
+    const tryConnect = () => {
+      const socket = new net.Socket();
+      socket.once('connect', () => {
+        socket.end();
+        resolve();
+      });
+      socket.once('error', (_) => {
+        if (Date.now() - startTime > timeout) {
+          reject(new Error(`Timeout waiting for port ${port} to open.`));
+        } else {
+          setTimeout(tryConnect, 500);
+        }
+      });
+      socket.connect(port, 'localhost');
+    };
+    tryConnect();
+  });
+}
+
+export async function ensureBinary(
+  executableName,
+  repo,
+  assetNameCallback,
+  binaryNameInArchive,
+  isJaeger = false,
+) {
+  const executablePath = path.join(BIN_DIR, executableName);
+  if (fileExists(executablePath)) {
+    console.log(`✅ ${executableName} already exists at ${executablePath}`);
+    return executablePath;
+  }
+
+  console.log(`🔍 ${executableName} not found. Downloading from ${repo}...`);
+
+  const platform = process.platform === 'win32' ? 'windows' : process.platform;
+  const arch = process.arch === 'x64' ? 'amd64' : process.arch;
+  const ext = platform === 'windows' ? 'zip' : 'tar.gz';
+
+  if (isJaeger && platform === 'windows' && arch === 'arm64') {
+    console.warn(
+      `⚠️ Jaeger does not have a release for Windows on ARM64. Skipping.`,
+    );
+    return null;
+  }
+
+  let release;
+  let asset;
+
+  if (isJaeger) {
+    console.log(`🔍 Finding latest Jaeger v2+ asset...`);
+    const releases = getJson(`https://api.github.com/repos/${repo}/releases`);
+    const sortedReleases = releases
+      .filter((r) => !r.prerelease && r.tag_name.startsWith('v'))
+      .sort((a, b) => {
+        const aVersion = a.tag_name.substring(1).split('.').map(Number);
+        const bVersion = b.tag_name.substring(1).split('.').map(Number);
+        for (let i = 0; i < Math.max(aVersion.length, bVersion.length); i++) {
+          if ((aVersion[i] || 0) > (bVersion[i] || 0)) return -1;
+          if ((aVersion[i] || 0) < (bVersion[i] || 0)) return 1;
+        }
+        return 0;
+      });
+
+    for (const r of sortedReleases) {
+      const expectedSuffix =
+        platform === 'windows'
+          ? `-${platform}-${arch}.zip`
+          : `-${platform}-${arch}.tar.gz`;
+      const foundAsset = r.assets.find(
+        (a) =>
+          a.name.startsWith('jaeger-2.') && a.name.endsWith(expectedSuffix),
+      );
+
+      if (foundAsset) {
+        release = r;
+        asset = foundAsset;
+        console.log(
+          `⬇️  Found ${asset.name} in release ${r.tag_name}, downloading...`,
+        );
+        break;
+      }
+    }
+    if (!asset) {
+      throw new Error(
+        `Could not find a suitable Jaeger v2 asset for platform ${platform}/${arch}.`,
+      );
+    }
+  } else {
+    release = getJson(`https://api.github.com/repos/${repo}/releases/latest`);
+    const version = release.tag_name.startsWith('v')
+      ? release.tag_name.substring(1)
+      : release.tag_name;
+    const assetName = assetNameCallback(version, platform, arch, ext);
+    asset = release.assets.find((a) => a.name === assetName);
+    if (!asset) {
+      throw new Error(
+        `Could not find a suitable asset for ${repo} (version ${version}) on platform ${platform}/${arch}. Searched for: ${assetName}`,
+      );
+    }
+  }
+
+  const downloadUrl = asset.browser_download_url;
+  const tmpDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'gemini-cli-telemetry-'),
+  );
+  const archivePath = path.join(tmpDir, asset.name);
+
+  try {
+    console.log(`⬇️  Downloading ${asset.name}...`);
+    downloadFile(downloadUrl, archivePath);
+    console.log(`📦 Extracting ${asset.name}...`);
+
+    const actualExt = asset.name.endsWith('.zip') ? 'zip' : 'tar.gz';
+
+    if (actualExt === 'zip') {
+      execSync(`unzip -o "${archivePath}" -d "${tmpDir}"`, { stdio: 'pipe' });
+    } else {
+      execSync(`tar -xzf "${archivePath}" -C "${tmpDir}"`, { stdio: 'pipe' });
+    }
+
+    const nameToFind = binaryNameInArchive || executableName;
+    const foundBinaryPath = findFile(tmpDir, (file) => {
+      if (platform === 'windows') {
+        return file === `${nameToFind}.exe`;
+      }
+      return file === nameToFind;
+    });
+
+    if (!foundBinaryPath) {
+      throw new Error(
+        `Could not find binary "${nameToFind}" in extracted archive at ${tmpDir}. Contents: ${fs.readdirSync(tmpDir).join(', ')}`,
+      );
+    }
+
+    fs.renameSync(foundBinaryPath, executablePath);
+
+    if (platform !== 'windows') {
+      fs.chmodSync(executablePath, '755');
+    }
+
+    console.log(`✅ ${executableName} installed at ${executablePath}`);
+    return executablePath;
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    if (fs.existsSync(archivePath)) {
+      fs.unlinkSync(archivePath);
+    }
+  }
+}
+
+export function manageTelemetrySettings(
+  enable,
+  oTelEndpoint = 'http://localhost:4317',
+  target = 'local',
+  originalSandboxSettingToRestore,
+) {
+  if (!fileExists(WORKSPACE_GEMINI_DIR)) {
+    fs.mkdirSync(WORKSPACE_GEMINI_DIR, { recursive: true });
+  }
+
+  const workspaceSettings = readJsonFile(WORKSPACE_SETTINGS_FILE);
+  const currentSandboxSetting = workspaceSettings.sandbox;
+  let settingsModified = false;
+
+  if (typeof workspaceSettings.telemetry !== 'object') {
+    workspaceSettings.telemetry = {};
+  }
+
+  if (enable) {
+    if (workspaceSettings.telemetry.enabled !== true) {
+      workspaceSettings.telemetry.enabled = true;
+      settingsModified = true;
+      console.log('⚙️  Enabled telemetry in workspace settings.');
+    }
+    if (workspaceSettings.sandbox !== false) {
+      workspaceSettings.sandbox = false;
+      settingsModified = true;
+      console.log('✅ Disabled sandbox mode for telemetry.');
+    }
+    if (workspaceSettings.telemetry.otlpEndpoint !== oTelEndpoint) {
+      workspaceSettings.telemetry.otlpEndpoint = oTelEndpoint;
+      settingsModified = true;
+      console.log(`🔧 Set telemetry OTLP endpoint to ${oTelEndpoint}.`);
+    }
+    if (workspaceSettings.telemetry.target !== target) {
+      workspaceSettings.telemetry.target = target;
+      settingsModified = true;
+      console.log(`🎯 Set telemetry target to ${target}.`);
+    }
+  } else {
+    if (workspaceSettings.telemetry.enabled === true) {
+      delete workspaceSettings.telemetry.enabled;
+      settingsModified = true;
+      console.log('⚙️  Disabled telemetry in workspace settings.');
+    }
+    if (workspaceSettings.telemetry.otlpEndpoint) {
+      delete workspaceSettings.telemetry.otlpEndpoint;
+      settingsModified = true;
+      console.log('🔧 Cleared telemetry OTLP endpoint.');
+    }
+    if (workspaceSettings.telemetry.target) {
+      delete workspaceSettings.telemetry.target;
+      settingsModified = true;
+      console.log('🎯 Cleared telemetry target.');
+    }
+    if (Object.keys(workspaceSettings.telemetry).length === 0) {
+      delete workspaceSettings.telemetry;
+    }
+
+    if (
+      originalSandboxSettingToRestore !== undefined &&
+      workspaceSettings.sandbox !== originalSandboxSettingToRestore
+    ) {
+      workspaceSettings.sandbox = originalSandboxSettingToRestore;
+      settingsModified = true;
+      console.log('✅ Restored original sandbox setting.');
+    }
+  }
+
+  if (settingsModified) {
+    writeJsonFile(WORKSPACE_SETTINGS_FILE, workspaceSettings);
+    console.log('✅ Workspace settings updated.');
+  } else {
+    console.log(
+      enable
+        ? '✅ Workspace settings are already configured for telemetry.'
+        : '✅ Workspace settings already reflect telemetry disabled.',
+    );
+  }
+  return currentSandboxSetting;
+}
+
+export function registerCleanup(
+  getProcesses,
+  getLogFileDescriptors,
+  originalSandboxSetting,
+) {
+  let cleanedUp = false;
+  const cleanup = () => {
+    if (cleanedUp) return;
+    cleanedUp = true;
+
+    console.log('\n👋 Shutting down...');
+
+    manageTelemetrySettings(false, null, originalSandboxSetting);
+
+    const processes = getProcesses ? getProcesses() : [];
+    processes.forEach((proc) => {
+      if (proc && proc.pid) {
+        const name = path.basename(proc.spawnfile);
+        try {
+          console.log(`🛑 Stopping ${name} (PID: ${proc.pid})...`);
+          process.kill(proc.pid, 'SIGTERM');
+          console.log(`✅ ${name} stopped.`);
+        } catch (e) {
+          if (e.code !== 'ESRCH') {
+            console.error(`Error stopping ${name}: ${e.message}`);
+          }
+        }
+      }
+    });
+
+    const logFileDescriptors = getLogFileDescriptors
+      ? getLogFileDescriptors()
+      : [];
+    logFileDescriptors.forEach((fd) => {
+      if (fd) {
+        try {
+          fs.closeSync(fd);
+        } catch (_) {
+          /* no-op */
+        }
+      }
+    });
+  };
+
+  process.on('exit', cleanup);
+  process.on('SIGINT', () => process.exit(0));
+  process.on('SIGTERM', () => process.exit(0));
+  process.on('uncaughtException', (err) => {
+    console.error('Uncaught Exception:', err);
+    cleanup();
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
This commit introduces a new observability feature that allows users to send telemetry data to their own Google Cloud project.

- Adds a new `docs/observability.md` file with detailed setup instructions.
- Adds a new `scripts/setup_workload_identity.sh` script to automate the setup of Workload Identity Federation.
- Updates `action.yml` to include the necessary inputs and steps for observability.
- Updates `README.md` to provide a high-level overview of the new feature.
@jerop
