### PR TITLE
Fix missing issue_comment trigger in gemini-pr-review workflow

### DIFF
--- a/examples/gemini-pr-review.yml
+++ b/examples/gemini-pr-review.yml
@@ -3,6 +3,8 @@ name: 🧐 Gemini Pull Request Review
 on:
   pull_request:
     types: [opened]
+  issue_comment:
+    types: [created]
   pull_request_review_comment:
     types: [created]
   pull_request_review:


### PR DESCRIPTION
The code-review workflow referenced `issue_comment` events in the job conditions but was missing the corresponding trigger in the `on:` section. This prevented the workflow from being triggered when users tried to initiate reviews via PR comments using `@gemini-cli /review`.